### PR TITLE
Add support for compiling on macOS (Darwin)

### DIFF
--- a/CODE/CFITSIO/Makefile
+++ b/CODE/CFITSIO/Makefile
@@ -5,7 +5,7 @@ target := libcfitsio.a
 
 # We copy the flags from the main Makefile, but we change O1 to O2 since that's what's used
 # already by cfitsio.
-cflags := -O2 -frounding-math -fsignaling-nans -mfpmath=sse -msse2 -march=x86-64 -mtune=generic
+cflags := -O2 -mfpmath=sse -msse2 -march=x86-64 -mtune=generic
 
 all: $(target)
 

--- a/CODE/Makefile
+++ b/CODE/Makefile
@@ -28,10 +28,41 @@ link_flags :=
 link_libs  := 
 # If not specified, do a static link
 static_link ?= 1
-ifeq ($(static_link),1)
-	linker := $(CC)
-	link_libs += -lgcc -lgfortran -lm
-	link_flags += -static
+
+platform := unknown
+ifeq ($(OS),Windows_NT)
+	# It's unknown how to treat this - let the user figure it out if they want
+	# to compile for Windows
+	platform := win
+else
+	# Run `uname` to check what OS this is
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		platform := linux
+		# We don't want to static link with libquadmath, so instead of
+		# using gfortran to link, we use gcc and explicitly link with
+		# libgcc, libfortran, and libm.
+		ifeq ($(static_link),1)
+			linker := $(FC)
+			link_flags += -nodefaultlibs -static
+			link_libs += -lgfortran -lm -lc -lgcc -lgcc_eh
+		endif
+	endif
+	ifeq ($(UNAME_S),Darwin)
+		platform := macos
+		# We can't static link on MacOS just by doing `-static` since
+		# Apple has made it impossible to statically link against their
+		# libSystem. We still do a dynamic link, but we statically link
+		# against all other libraries that we need.
+		# We need to manually locate the libraries to link statically
+		# and specify the archive or object files on the command line,
+		# instead of the `-l` option.
+		ifeq ($(static_link),1)
+			linker := $(FC)
+			link_flags += -nodefaultlibs -static-libgcc
+			link_libs += $(shell sh TOOLS/DarwinFindLibraryArchive.sh)
+		endif
+	endif
 endif
 
 # Target executables (must have <file>.f in the current directory)

--- a/CODE/Makefile
+++ b/CODE/Makefile
@@ -56,11 +56,12 @@ else
 		# against all other libraries that we need.
 		# We need to manually locate the libraries to link statically
 		# and specify the archive or object files on the command line,
-		# instead of the `-l` option.
+		# instead of the `-l` option, with the exception of -lSystem, which we
+		# dynamically link with.
 		ifeq ($(static_link),1)
 			linker := $(FC)
 			link_flags += -nodefaultlibs -static-libgcc
-			link_libs += $(shell sh TOOLS/DarwinFindLibraryArchive.sh)
+			link_libs += $(shell sh TOOLS/DarwinFindLibraryArchive.sh) -lSystem
 		endif
 	endif
 endif

--- a/CODE/TOOLS/DarwinFindLibraryArchive.sh
+++ b/CODE/TOOLS/DarwinFindLibraryArchive.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+function panic {
+    echo "ERROR: $1" >&2
+    exit 1
+}
+function resolve_lib {
+    lib="${1#-l}"
+    oldIFS="$IFS"
+    IFS=":"
+    file=""
+    for dir in $gfort_library_path ; do
+        [ -d "$dir" ] || continue
+        file="$dir/lib$lib.a" ; [ -f "$file" ] && break
+        file="$dir/lib$lib.o" ; [ -f "$file" ] && break
+        file=""
+    done
+    IFS="$oldIFS"
+    if [ -f "$file" ] ; then
+        resolved_lib="$file"
+        return 0
+    else
+        resolved_lib=""
+        return 1
+    fi
+}
+fortest="./fortest.f"
+fortest_exe="./fortest"
+[ -f "${fortest}" ] && panic "${fortest} already exists"
+[ -f "${fortest_exe}" ] && panic "${fortest_exe} already exists"
+
+cat >"${fortest}" <<END
+      end
+END
+gfort_library_path="`gfortran -### -o "${fortest_exe}" "${fortest}" 2>&1 | grep "LIBRARY_PATH" | sed -e s/LIBRARY_PATH=//`"
+gfort_libraries="`gfortran -### --static -o "${fortest_exe}" "${fortest}" 2>&1 | grep "collect" | fmt -1 | grep -e '^ *-l' -e '.a$' | grep -v -e "-lcrt0" -e "-lSystem" -e "-lm" -e "-lquadmath" | fmt -999`"
+
+lib_to_use=""
+for lib in ${gfort_libraries} ; do
+    if ( echo "${lib}" | grep "^-l" >/dev/null ) ; then
+        resolve_lib "${lib}" || panic "Unable to resolve library ${lib}"
+        lib="$resolved_lib"
+    fi
+    lib_to_use="${lib_to_use} ${lib}"
+done
+echo "${lib_to_use}" "${lib_to_use}"
+rm "${fortest}"

--- a/TESTS/NiceDiffOutput.sed
+++ b/TESTS/NiceDiffOutput.sed
@@ -1,0 +1,34 @@
+#n
+# If we match the "start" string, branch forward.
+/Best fitting values/b mloop
+# Otherwise, delete line and restart.
+d
+
+:mloop
+# Read in new line
+n
+
+# If we have found the end string, quit.
+/^Degrees of freedom in fit/{
+    q
+}
+
+# If line matches any number of things we don't want to print,
+# ignore it and go back to start of loop.
+/^-----/{
+    b mloop
+}
+/^# points Dn used in fit/{
+    b mloop
+}
+/^Minimization Details/{
+    b mloop
+}
+# Skip blank lines
+/^\s*$/{
+    b mloop
+}
+
+# Otherwise, print string and loop
+p
+b mloop

--- a/TESTS/NiceDiffOutput.sh
+++ b/TESTS/NiceDiffOutput.sh
@@ -2,33 +2,7 @@
 function extract() {
 	file="$1"
 	prefix="$2"
-	cat "${file}" | sed -n -f <( cat <<-SEDSCR
-		# If we match the "start" string, branch forward.
-		/Best fitting values/b mloop
-		# Otherwise, delete line and restart.
-		d
-
-		:mloop
-		# Read in new line
-		n
-
-		# If we have found the end string, quit.
-		/^Degrees of freedom in fit/{q}
-
-		# If line matches any number of things we don't want to print,
-		# ignore it and go back to start of loop.
-		/^-----/{ z ; b mloop }
-		/^# points Dn used in fit/{ z ; b mloop }
-		/^Minimization Details/{ z ; b mloop }
-		# Skip blank lines
-		/^\s*$/{ z ; b mloop }
-
-		# Otherwise, print string and loop
-		s|^|${prefix} |
-		p
-		b mloop
-SEDSCR
-	)
+	cat "${file}" | sed -f NiceDiffOutput.sed | sed -e "s/^/${prefix} /"
 }
 function gen_equals() {
 	count="$1"

--- a/TESTS/RunSingleTest.sh
+++ b/TESTS/RunSingleTest.sh
@@ -63,21 +63,23 @@ fi
 
 # Determine what DiskFit input and output files are being used
 echo "=== Reading testfile '$testfile'..."
-diskfit_input_file=$(sed -Ee "5{s/'([^']+)'/\\1/;q};d" < "$testfile")
+diskfit_input_file=$(sed -e "5{" -e "s/'\([^']*\)'/\1/" -e "q" -e "}" -e "d" < "$testfile")
 echo "=== Using DiskFit input  file '$diskfit_input_file'..."
 [ -f "$diskfit_input_file" ] || panic "DiskFit input file '$diskfit_input_file' doesn't exist!"
-diskfit_output_file=$(sed -Ee "8{s/'([^']+)'\s*#?.*/\\1/;q};d" < "$diskfit_input_file")
+diskfit_output_file=$(sed -e "8{" -e "s/'\([^']*\)'[[:space:]]*#*.*/\1/" -e "q" -e "}" -e "d" < "$diskfit_input_file")
+[ -z "$diskfit_output_file" ] && panic "Unable to read output file from input file!"
 echo "=== Using DiskFit output file '$diskfit_output_file'..."
 diskfit_output_file_no_ext="${diskfit_output_file%\.out}"
 
 # Clear output directory
 diskfit_output_directory=$(dirname "$diskfit_output_file")
+[ -z "$diskfit_output_directory" -o "$diskfit_output_directory" = "." ] && panic "Invalid output directory '$diskfit_output_directory'"
 echo "=== Cleaning up output directory '$diskfit_output_directory'..."
-mkdir -vp "$diskfit_output_directory"
-rm -vf "$diskfit_output_directory"/*
+mkdir -p "$diskfit_output_directory"
+rm -f "$diskfit_output_directory"/*
 
 # Double-check expected directory
-expected_directory=$(sed -Ee "3q;d" < "$testfile")
+expected_directory=$(sed -e "3q" -e "d" < "$testfile")
 echo "=== Using expected outputs directory '$expected_directory'..."
 [ -d "$expected_directory" ] || echo "WARNING: Expected outputs directory '$expected_directory' doesn't exist!"
 


### PR DESCRIPTION
This adds macOS compilation support to the new DiskFit Makefile system. This is overcomplicated due to our inability to create static executables on macOS since there is no static version of `libSystem.dylib`. Instead, we need to use a helper script to determine the location of every static archive or object file used during static compilation, and then statically link those by specifying their paths on the command line, while still linking dynamically with libSystem. This is done using the `DarwinFindLibraryArchive.sh` shell script, which is run in the macOS-only codepath in the Makefile.

There have also been additional changes to remove the use of GNU sed specific extensions, so that the shell scripts work correctly on macOS which does not have GNU sed.