### PR TITLE
Prevent `getcwd` compilation error when compiling CFITSIO on MacOS

### DIFF
--- a/CODE/CFITSIO/Makefile
+++ b/CODE/CFITSIO/Makefile
@@ -8,6 +8,8 @@ target := libcfitsio.a
 cflags := -O2 -mfpmath=sse -msse2 -march=x86-64 -mtune=generic
 
 ifeq ($(platform),macos)
+	# This causes `unistd.h` to be included when compiling `group.c`, preventing the
+	# following error: "implicit declaration of function 'getcwd'"
 	cflags += -Dunix=1
 endif
 

--- a/CODE/CFITSIO/Makefile
+++ b/CODE/CFITSIO/Makefile
@@ -7,6 +7,10 @@ target := libcfitsio.a
 # already by cfitsio.
 cflags := -O2 -mfpmath=sse -msse2 -march=x86-64 -mtune=generic
 
+ifeq ($(platform),macos)
+	cflags += -Dunix=1
+endif
+
 all: $(target)
 
 $(target): $(cfitsio_dir)/libcfitsio.a

--- a/CODE/Makefile
+++ b/CODE/Makefile
@@ -100,7 +100,7 @@ $(obj_targets) $(obj_common): $(obj_modules) COMMON/commons.h
 
 # Build libcfitsio.a using the makefile in the subdirectory.
 CFITSIO/libcfitsio.a:
-	$(MAKE) -C CFITSIO libcfitsio.a
+	$(MAKE) -C CFITSIO libcfitsio.a platform=$(platform)
 
 # New target for generating assembly source from all Fortran files.
 # Used only for debugging.


### PR DESCRIPTION
This change adds an extra flag to the `libcfitsio` compilation which allows it to include the header file required for `getcwd`.

When compiling without this change on my Macbook, I receive a warning about `getcwd` but the compilation continues, but on different versions of MacOS, this will be a fatal error.

When compiling with this change, I do not see any warnings relating to `getcwd`.

For reference, this is the compiler version on my Macbook:
```
Apple LLVM version 10.0.1 (clang-1001.0.46.4)
Target: x86_64-apple-darwin18.7.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```